### PR TITLE
Add CDM mapping and vendor capabilities for CarbonBlack

### DIFF
--- a/vendors/carbonblack.json
+++ b/vendors/carbonblack.json
@@ -1,6 +1,6 @@
 {
   "name": "Carbon Black",
-  "productCapabilities": ["anti-malware", "av", "edr", "endpoint detection", "endpoint response", "etdr"],
+  "productCapabilities": ["anti-malware", "anti-virus", "av", "edr", "endpoint detection", "endpoint response", "endpoint detection and response", "endpoint threat detection and response"],
   "description": "VMware Carbon Black Endpoint consolidates multiple endpoint security capabilities using one agent and console.",
   "iconWebLink": "",
   "webLink": "https://www.vmware.com/products/carbon-black-cloud-endpoint.html",

--- a/vendors/carbonblack.json
+++ b/vendors/carbonblack.json
@@ -1,8 +1,19 @@
 {
   "name": "Carbon Black",
+  "productCapabilities": ["anti-malware", "av", "edr", "endpoint detection", "endpoint response", "etdr"],
+  "description": "VMware Carbon Black Endpoint consolidates multiple endpoint security capabilities using one agent and console.",
   "iconWebLink": "",
+  "webLink": "https://www.vmware.com/products/carbon-black-cloud-endpoint.html",
+  "website": "https://www.vmware.com/products/carbon-black-cloud-endpoint.html",
   "linkToDPA": "https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/downloads/eula/vmware-data-processing-addendum.pdf",
   "linkToSLA": "https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/downloads/eula/vmw-carbon-black-hosted-edr-service-agreement.pdf",
   "_type": "carbon_black",
-  "aliases": []
+  "aliases": ["confer", "bit9 + carbon black", "vmware carbon black"],
+  "cyberDefenseMatrixMap": {
+    "devices": ["protect", "detect", "respond"],
+    "applications": [],
+    "networks": [],
+    "data": [],
+    "users": []
+  }
 }


### PR DESCRIPTION
Exploring a new schema for capturing CyberDefenseMatrix (CDM) metadata.

Adds CDM mapping, product capabilities (in nearest
industry-standard terms), and description properties.

NOTE: If at some point we want to *ENFORCE* the presence of the
productCapabilities and cyberDefenseMatrixMapping properties, we will need to
modify the Vendor.json schema and also the validation tool here:

https://github.com/jupiterone/vendor-stack/blob/4afef2d6010c6af77bf5b49a4086d386b2247293/tools/validateVendors.js