### PR TITLE
Remove Mercury from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jupiterone/data-pipeline @jupiterone/mercury @jupiterone/security
+* @jupiterone/data-pipeline @jupiterone/security


### PR DESCRIPTION
Mercury doesn't need to get notified on this repo - it's too broad of a brush.